### PR TITLE
Update python environment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,11 +7,13 @@ Unreleased
 - Default parser is switched to cfparse. Step name is compiled to cfparse
 - Step functions could get compiled instances of parse, cfparse and re.compile directly
 - Fix support of test step render by pytest parametrization dropped in release 5.0.0 adding adapter between fixtures and examples
-- Refuse usage of pytest versions 4.3, 4.4
+- Drop pytest 4
+- Drop python 3.6
 - Added tags support for Examples sections
 - Added joining by parameters between examples sections on different levels (and with fixtures)
 - Step could override multiple fixtures using ``target_fixtures`` parameter
 - Default step parameters injection as fixtures behavior could be changed by ``params_fixtures_mapping`` step parameter
+
 
 5.0.0
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=58", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 120
-target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
+target-version = ['py37', 'py38', 'py39', 'py310']
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,13 +19,13 @@ classifiers =
     Topic :: Software Development :: Libraries
     Topic :: Utilities
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     ;Already used in pytest
     attrs
@@ -34,9 +34,9 @@ install_requires =
     Mako
     ordered_set
     parse
-    parse_type
+    parse_type>=0.6.0
     py
-    pytest>=4.5
+    pytest>=5.0
 
 tests_require = tox
 packages = pytest_bdd

--- a/tests/scripts/test_generate.py
+++ b/tests/scripts/test_generate.py
@@ -176,9 +176,6 @@ def test_unicode_characters(testdir, monkeypatch):
         ),
     )
 
-    if sys.version_info < (3, 7):
-        monkeypatch.setenv("PYTHONIOENCODING", "utf-8")
-
     result = testdir.run("pytest-bdd", "generate", "unicode_characters.feature")
     expected_output = textwrap.dedent(
         '''\

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 distshare = {homedir}/.tox/distshare
 envlist = py310-pytestlatest-linters,
-          py39-pytest{45,46,50,51,52,53,54,60,61,62, latest}-coverage,
-          py{36,37,38,310}-pytestlatest-coverage,
-          py39-pytestlatest-xdist-coverage
+          py310-pytest{625, latest}-coverage,
+          py39-pytest{50,51,52,53,54,60,61,62}-coverage,
+          py{37,38,39}-pytestlatest-coverage,
+          py310-pytestlatest-xdist-coverage
 skip_missing_interpreters = true
 
 [testenv]
@@ -12,6 +13,7 @@ setenv =
     xdist: _PYTEST_MORE_ARGS=-n3 -rfsxX
 deps =
     pytestlatest: pytest
+    pytest625: pytest~=6.2.5
     pytest62: pytest~=6.2.0
     pytest61: pytest~=6.1.0
     pytest60: pytest~=6.0.0
@@ -20,8 +22,6 @@ deps =
     pytest52: pytest~=5.2.0
     pytest51: pytest~=5.1.0
     pytest50: pytest~=5.0.0
-    pytest46: pytest~=4.6.0
-    pytest45: pytest~=4.5.0
 
     coverage: coverage
     xdist: pytest-xdist
@@ -30,11 +30,10 @@ commands = {env:_PYTEST_CMD:pytest} {env:_PYTEST_MORE_ARGS:} {posargs:-vvl}
 
 [testenv:py310-pytestlatest-linters]
 deps = black~=22.0
-commands = black --verbose setup.py docs pytest_bdd tests
+commands = black --check --verbose setup.py docs pytest_bdd tests
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
- Drop python 3.6 because of EOL
- Drop pytest<5 (Actually there wasn't reason to support 4.x version because they are about 3.4/2.7 python support, which already dropped)
- Fix source distribution build