### PR TITLE
Execute step definitions as if they were pytest fixture.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Unreleased
 - Added joining by parameters between examples sections on different levels (and with fixtures)
 - Step could override multiple fixtures using ``target_fixtures`` parameter
 - Default step parameters injection as fixtures behavior could be changed by ``params_fixtures_mapping`` step parameter
+- Step definitions can have "yield" statements again (4.0 release broke it). They will be executed as normal fixtures: code after the yield is executed during teardown of the test. (youtux)
 
 
 5.0.0

--- a/pytest_bdd/scenario.py
+++ b/pytest_bdd/scenario.py
@@ -20,7 +20,7 @@ from itertools import tee, zip_longest
 from warnings import warn
 
 import pytest
-from _pytest.fixtures import FixtureLookupError
+from _pytest.fixtures import FixtureLookupError, call_fixture_func
 from _pytest.warning_types import PytestDeprecationWarning
 
 from . import exceptions
@@ -133,8 +133,8 @@ def _execute_step_function(request, scenario, step, step_func, step_params):
 
         request.config.hook.pytest_bdd_before_step_call(**kw)
 
-        # Execute the step.
-        step_result = step_func(**kwargs)
+        # Execute the step as if it was a pytest fixture, so that we can allow "yield" statements in it
+        step_result = call_fixture_func(fixturefunc=step_func, request=request, kwargs=kwargs)
 
         if len(step_func.target_fixtures) == 1:
             injectable_fixtures = [(step_func.target_fixtures[0], step_result)]


### PR DESCRIPTION
This way we can get the same behaviour of yield-fixtures.